### PR TITLE
remove unnecessary or hardcoded directives from sql scripts

### DIFF
--- a/mapmap-server/scripts-bbdd/data.sql
+++ b/mapmap-server/scripts-bbdd/data.sql
@@ -1,3 +1,2 @@
-\c mapmap
 insert into agency (id, color, gtfsagencyid, lang, name, phone, systemmap, timezone, url)
 values (1, '#000000', 'CMX', 'es', 'Codeando Mexico', '', true, 'GMT-6', 'https://codeandomexico.org');

--- a/mapmap-server/scripts-bbdd/schema.sql
+++ b/mapmap-server/scripts-bbdd/schema.sql
@@ -15,27 +15,6 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
-
-CREATE DATABASE "mapmap"
-    WITH OWNER "postgres"
-    ENCODING 'UTF8';
-
-\c mapmap
-
---
--- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
-
-
---
--- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION postgis IS 'PostGIS geometry and geography spatial types and functions';
-
-
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -325,24 +304,6 @@ ALTER TABLE ONLY public.route
 ALTER TABLE ONLY public.route
     ADD CONSTRAINT fkpjyc40ihe8p6u2y5t0pwo17o3 FOREIGN KEY (agency_id) REFERENCES public.agency(id);
 
-
---
--- PostgreSQL database dump complete
---
-
-
-
-
---
--- TOC entry 4634 (class 0 OID 0)
--- Dependencies: 17
--- Name: SCHEMA public; Type: ACL; Schema: -; Owner: postgres
---
-
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON SCHEMA public FROM postgres;
-GRANT ALL ON SCHEMA public TO postgres;
-GRANT ALL ON SCHEMA public TO PUBLIC;
 
 --
 -- PostgreSQL database dump complete


### PR DESCRIPTION
un resumen de las cosas que cambiaron:

* elimina el nombre hardcodeado de la base de datos para permitir que se puedan usar los scripts indistintamente de cómo la hayas nombrado
* elimina la primera línea de `data.sql` pues usa el nombre hardcodeado de la base de datos y además no es necesario pues se pasa el nombre de la base de datos por línea de comandos cuando se corre `psql`.
* elimina las líneas de creación de la base de datos del script del schema. La documentación de por si establece que está fuera de su alcance este proceso, y el nombre está hardcodeado. Quitar la línea de creación y conexión permite correr el script independientemente del nombre de la bd y del nivel de acceso del usuario (actualmente requiere el permiso CREATE que suelen tener solo superusuarios)
* elimina la linea de instalación de la extensión postgis. La documentación también dice que está fuera del alcance, el nombre está hardcodeado y se necesitan altos privilegios para que funcione. Además en el caso del contenedor esta extensión ya está  instalada en la base de datos desde el principio.
* elimina líneas redundantes GRANT del final del script sql. No sé por qué son necesarias, pero parecen redundantes: eliminan y crean los mismos permisos de los mismos usuarios