### PR TITLE
a dockerfile that builds the jar

### DIFF
--- a/.github/workflows/build-server-jar.yml
+++ b/.github/workflows/build-server-jar.yml
@@ -4,7 +4,7 @@ name: Build Server JAR
 
 on:
     workflow_call
-    
+
 jobs:
   build-jar:
 
@@ -23,7 +23,7 @@ jobs:
         cache: maven
         server-id: github
         settings-path: ${{ github.workspace }}/mapmap-server
-        
+
     - name: Build with Maven
       run: mvn -B package --file mapmap-server/pom.xml -Dmaven.test.skip
 
@@ -31,11 +31,11 @@ jobs:
       run: mvn deploy --file mapmap-server/pom.xml -s $GITHUB_WORKSPACE/mapmap-server/settings.xml -Dmaven.test.skip
       env:
         GITHUB_TOKEN: ${{ github.token }}
-    
+
     - name: Rename JAR
       run: |
         mv "mapmap-server/target/mapmap-server-0.0.1-SNAPSHOT.jar" "mapmap-server.jar"
-    
+
     - name: Cache JAR
       id: cache-jar
       uses: actions/cache@v3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,18 @@
 # Este fichero se usa para generar la imagen de Docker de produccion usando GitHub Actions
 # https://github.com/CodeandoMexico/mapmap/blob/main/.github/workflows/build-server-docker-image.yml
 
-FROM eclipse-temurin:17
+FROM docker.io/eclipse-temurin:17-jdk-jammy as build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    maven \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY mapmap-server/ ./mapmap-server
+
+RUN mvn -B package --file mapmap-server/pom.xml -Dmaven.test.skip
+RUN mv mapmap-server/target/mapmap-server-0.0.1-SNAPSHOT.jar /mapmap-server.jar
+
+FROM docker.io/eclipse-temurin:17-jre-jammy
 
 LABEL org.opencontainers.image.source="https://github.com/codeandomexico/mapmap"
 
@@ -12,6 +23,6 @@ ENV LOGGIN_LEVEL INFO
 
 WORKDIR /mapmap-server
 
-COPY mapmap-server.jar .
+COPY --from=build /mapmap-server.jar .
 
 ENTRYPOINT java -jar /mapmap-server/mapmap-server.jar --spring.datasource.url='${DATABASE_URL}' --spring.datasource.username='${DATABASE_USER}' --spring.datasource.password='${DATABASE_PASSWORD}' --logging.level.root='${LOGGIN_LEVEL}'

--- a/docs/instalacion.md
+++ b/docs/instalacion.md
@@ -33,7 +33,7 @@ En la carpeta mapmap-server/scripts-bbdd hay dos scripts de SQL:
 Versiones:
     * Java 17+
     * Maven 3.9.1+
-    *
+
 En este documento no se explica como instalar esto.
 
 5. Descargar el código del proyecto


### PR DESCRIPTION
Aquí se añade un paso de construcción al Dockerfile que compila el jar del servidor y después lo copia a la imagen final. Se usa una imagen intermedia para que las cosas necesarias durante la construcción no se queden haciendo peso en la imagen final.

Una de las ideas más valiosas de usar contenedores es no tener ninguna dependencia del entorno para poder construirlos y usarlos. O sea que sean auto-contenidos. El Dockerfile actual depende de la existencia del jar, que depende del entorno, entonces para construir la imagen de contenedor en local sería necesario el jdk de java, lo cual va contra su propósito.

Con estos cambios basta con tener docker/podman en tu equipo y es posible construir la imagen en local sin más ni más.  Esto podría (aunque no estoy seguro) además simplificar el proceso de construcción del jar en CI pues ahora un solo paso hace el jar y la imagen (suponiendo que se puede extraer el jar de la imagen construida).

Nótese también que estos cambios logran una imagen más ligera. Probablemente se deba al uso del JRE solamente en vez del JDK completo en la imagen final

```
localhost/mapmap                                             latest                d4fb1dde3e00  28 minutes ago     350 MB
ghcr.io/codeandomexico/mapmap/production                     1.1.0                 9640326802e8  6 hours ago        540 MB
```