### PR TITLE
automatically select the tag for the container image

### DIFF
--- a/.github/workflows/build-server-docker-image.yml
+++ b/.github/workflows/build-server-docker-image.yml
@@ -24,10 +24,11 @@ jobs:
           key: mapmap-server-jar
 
       - name: Build Docker Image
-        uses: VaultVulp/gp-docker-action@1.2.0
+        uses: VaultVulp/gp-docker-action@1.6.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           image-name: production
-          image-tag: 1.1.2
+          extract-git-tag: true
+          additional-image-tags: latest
           dockerfile: docker/Dockerfile
           build-context: .


### PR DESCRIPTION
Esto permite que solamente con que añadamos un tag al repositorio en local la imagen se publique de forma correta. Nos evita estar cambiando el archivo de workflow en cada tag y automatiza y hace un poco más limpio el proceso.

Con este cambio bastaría con añadir la etiqueta `x.y.x` (`git tag x.y.z && git push --tags`) para tener la imagen `production:x.y.z`.